### PR TITLE
Fix a account header typo.

### DIFF
--- a/src/com/augur/tacacs/SessionClient.java
+++ b/src/com/augur/tacacs/SessionClient.java
@@ -211,7 +211,7 @@ public class SessionClient extends Session
 		) { throw new IOException("Invalid Accounting flags"); }
 		tacacs.write(new AcctRequest
 		(
-			new Header(TAC_PLUS.PACKET.VERSION.v13_0, TAC_PLUS.PACKET.TYPE.AUTHOR,id,singleConnect), 
+			new Header(TAC_PLUS.PACKET.VERSION.v13_0, TAC_PLUS.PACKET.TYPE.ACCT,id,singleConnect), 
 			flags,
 			authen_meth,
 			TAC_PLUS.PRIV_LVL.USER.code(),


### PR DESCRIPTION
Sending account with AUTHOR header will get a authorReply. Java will report that reply can't cast to acctReply. It may be a typo in header flag.
