### PR TITLE
Allow TacacsClient to create a session with unencrypted payload.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /nbproject/
 /build/classes/
 /dist/
+.idea/
+*.iml

--- a/src/com/augur/tacacs/Header.java
+++ b/src/com/augur/tacacs/Header.java
@@ -43,8 +43,7 @@ public class Header
 	}
 	
 	
-	private Header(byte seqNum, byte flags, TAC_PLUS.PACKET.VERSION version, TAC_PLUS.PACKET.TYPE type, byte[] sessionID)
-	{
+	private Header(byte seqNum, byte flags, TAC_PLUS.PACKET.VERSION version, TAC_PLUS.PACKET.TYPE type, byte[] sessionID) {
 		this.seqNum = seqNum;
 		this.flags = flags;
 		this.version = version;
@@ -52,14 +51,13 @@ public class Header
 		this.sessionID = sessionID;
 		this.bodyLength = -1;
 	}
-	
-	Header(TAC_PLUS.PACKET.VERSION version, TAC_PLUS.PACKET.TYPE type, byte[] sessionID, boolean singleConnect)
-	{
+
+	Header(byte flags, TAC_PLUS.PACKET.VERSION version, TAC_PLUS.PACKET.TYPE type, byte[] sessionID) {
 		this(
-			(byte)1, 
-			singleConnect? TAC_PLUS.PACKET.FLAG.SINGLE_CONNECT.code() : 0, 
-			version, 
-			type, 
+			(byte)1,
+			flags,
+			version,
+			type,
 			sessionID
 		);
 	}


### PR DESCRIPTION
This change allows a TacacsClient to create a session with the unencrypted flag.  This is useful (and sometimes necessary) for connecting to TacacsServers that don't require or allow data to be encrypted.

This is to resolve https://github.com/AugurSystems/TACACS/issues/2