### PR TITLE
fix bug where getPAPInstance method not initializing username

### DIFF
--- a/src/com/augur/tacacs/UserInterface.java
+++ b/src/com/augur/tacacs/UserInterface.java
@@ -31,10 +31,13 @@ public abstract class UserInterface
 	 * Creates an instance that that will return the given username and password 
 	 * when prompted; useful for simulating a PAP-like response to an interactive (ASCII) interface.
 	 */
-	public static final UserInterface getPAPInstance(final String username, final String password)
+	public static final UserInterface getPAPInstance(final String usernameLocal, final String password)
 	{
 		return new UserInterface()
 		{
+			{
+				this.username = usernameLocal;
+			}
 			@Override public String getUserInput(String prompt, boolean noEcho, TAC_PLUS.AUTHEN.STATUS getWhat)
 			{
 				switch(getWhat)


### PR DESCRIPTION
The anonymous inner class created in UserInterface.getPAPInstance did not appear to be have set the outer class's instance variable "username" so I initialized it in an initialization block.  Before this change, a null would have been returned if getUserInput asked for the user.