### PR TITLE
fixed message parsing issue

### DIFF
--- a/src/com/augur/tacacs/AuthorReply.java
+++ b/src/com/augur/tacacs/AuthorReply.java
@@ -49,7 +49,7 @@ public class AuthorReply extends Packet
 		int dataLen = toInt(body[4],body[5]);
 		int arg_cnt = body[1] & FF;
 		int chkLen = overhead + arg_cnt + msgLen + dataLen;
-		for (int i=0; i<arg_cnt; i++) { chkLen += body[overhead+i]; }
+		for (int i=0; i<arg_cnt; i++) { chkLen += body[overhead+i] & FF; }
 		if (chkLen != body.length) { throw new IOException("Corrupt packet or bad key"); }
 		//
 		status = TAC_PLUS.AUTHOR.STATUS.forCode(body[0]);
@@ -57,7 +57,7 @@ public class AuthorReply extends Packet
 		int argOffset = 6 + arg_cnt + msgLen + dataLen;
 		for (int i=0; i<arg_cnt; i++)
 		{
-			int argLen = body[6+i];
+			int argLen = body[6+i] & FF ;
 			arguments[i] = new Argument(new String(Arrays.copyOfRange(body, argOffset, argOffset+argLen),StandardCharsets.UTF_8));
 			argOffset += argLen;
 		}


### PR DESCRIPTION
API throws an exception for valid input.

Tested this library with tacacs+ server ( http://tacacs.net ).
When a user configures vendor specific attributes at tacacs+ server where some attributes has length more than 127 ( and less than 255 ), this API throws an exception.
Byte cannot be assigned directly to int if packet contains value greater than 127.

for example, AT TACACS+ server I configured vendor specific attribute as:
<Set>perm=abcdef-xxxxx-yyyyyyyy-zzzzz+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++</Set>