### PR TITLE
Fix priv_lvl field of authentication request

### DIFF
--- a/src/com/augur/tacacs/SessionClient.java
+++ b/src/com/augur/tacacs/SessionClient.java
@@ -133,7 +133,7 @@ public class SessionClient extends Session
 		(
 			new Header(this.headerFlags, TAC_PLUS.PACKET.VERSION.v13_0, TAC_PLUS.PACKET.TYPE.AUTHEN,id),
 			TAC_PLUS.AUTHEN.ACTION.LOGIN, 
-			TAC_PLUS.PRIV_LVL.MIN.code(), 
+			priv_lvl,
 			TAC_PLUS.AUTHEN.TYPE.ASCII, 
 			TAC_PLUS.AUTHEN.SVC.NONE, 
 			null, // server will prompts for username
@@ -163,7 +163,7 @@ public class SessionClient extends Session
 		(
 			new Header(this.headerFlags, TAC_PLUS.PACKET.VERSION.v13_1, TAC_PLUS.PACKET.TYPE.AUTHEN,id),
 			TAC_PLUS.AUTHEN.ACTION.LOGIN, 
-			TAC_PLUS.PRIV_LVL.MIN.code(), 
+			priv_lvl,
 			TAC_PLUS.AUTHEN.TYPE.PAP, 
 			TAC_PLUS.AUTHEN.SVC.NONE, 
 			username, 
@@ -210,7 +210,7 @@ public class SessionClient extends Session
 		(
 			new Header(this.headerFlags, TAC_PLUS.PACKET.VERSION.v13_1, TAC_PLUS.PACKET.TYPE.AUTHEN,id),
 			TAC_PLUS.AUTHEN.ACTION.LOGIN, 
-			TAC_PLUS.PRIV_LVL.MIN.code(), 
+			priv_lvl,
 			TAC_PLUS.AUTHEN.TYPE.CHAP, 
 			TAC_PLUS.AUTHEN.SVC.NONE, 
 			username, 


### PR DESCRIPTION
Previously the priv_lvl specified when constructing a new
SessionClient was ignored when the SessionClient was used to perform
an authentication. Instead, the authentication request just included
MIN priv level (0) always. This patch fixes this (Fixes #9 ).